### PR TITLE
MMS and SMS deduping

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Big thanks to [`radj`](https://github.com/radj) for [the original project](https
 
 # Example Usage
 
-Need to have Python 2.x installed.
+Need to have Python 3.x installed.
+
+Default region constant can be updated by setting `DEFAULT_REGION`, used for phone number duplicate detection between SMS/MMS.
 
 ## With single file
 `python clean.py -i ~/SMSBackupRestore/big_backup.xml -o output_file.xml`

--- a/clean.py
+++ b/clean.py
@@ -1,32 +1,42 @@
 import sqlite3
+
 try:
     from lxml.etree import ETCompatXMLParser
+
     custom_parser = ETCompatXMLParser(huge_tree=True, recover=True)
 except ImportError:
     custom_parser = None
+
 
 try:
     import xml.etree.cElementTree as XML
 except ImportError:
     import xml.etree.ElementTree as XML
-import logging as log
-from datetime import datetime
+
 import argparse
-import glob, fnmatch, os, re
+import fnmatch
+import glob
+import logging as log
+import os
+import re
+from datetime import datetime
+
+import phonenumbers
 
 #    TODO SMSCOUNT backup_set backup_date
 #
 
 GLOB_ID_MMS = 0
+DEFAULT_REGION = "US"
 
 
 def main(input_paths, output_path):
     try:
         time_start = datetime.now()
-        log.basicConfig(level=log.DEBUG, format='%(asctime)s %(message)s')
-        log.debug('Starting Operation...')
-        conn = sqlite3.connect('sms.db')
-        conn.execute('DELETE FROM smss')
+        log.basicConfig(level=log.DEBUG, format="%(asctime)s %(message)s")
+        log.debug("Starting Operation...")
+        conn = sqlite3.connect("sms.db")
+        conn.execute("DELETE FROM smss")
         conn.execute("DELETE FROM mmss")
         conn.execute("DELETE FROM parts")
         conn.execute("DELETE FROM addrs")
@@ -37,17 +47,22 @@ def main(input_paths, output_path):
             log.debug("Parsing XML file: ")
             tree = XML.parse(xml_filename, parser=custom_parser)
             log.debug("Done.")
-            load_into_db(conn, tree)
+            total_records = load_into_db(conn, tree)
 
-        add_sms(conn, root)
-        add_mms(conn, root)
+        print("Loaded sms.db with {} messages.".format(total_records))
+        sms_uniques = add_sms(conn, root)
+        duplicates_skipped = add_mms(conn, root, sms_uniques)
+        print("Skipped {} MMS duplicates of SMS".format(duplicates_skipped))
         conn.close()
-        #append_mms(mms_list, root)
+        # append_mms(mms_list, root)
         write_file(output_path, root)
         time_end = datetime.now()
-        log.debug('Operation completed in %d seconds.' % ((time_end - time_start).total_seconds()))
+        log.debug(
+            "Operation completed in %d seconds."
+            % ((time_end - time_start).total_seconds())
+        )
     finally:
-        if 'conn' in locals():
+        if "conn" in locals():
             conn.close()
 
 
@@ -62,6 +77,26 @@ def append_mms(mms_list, root):
         root.extend(mms)
 
 
+def format_number(address):
+    try:
+        return phonenumbers.format_number(
+            phonenumbers.parse(address, DEFAULT_REGION),
+            phonenumbers.PhoneNumberFormat.INTERNATIONAL,
+        )
+    except phonenumbers.NumberParseException:
+        log.exception("Returning address unformatted: {}".format(address))
+        return address
+
+
+def make_unique_message_key(row):
+    key = "{}-{}-{}".format(
+        format_number(row[1]),  # address
+        row[3],  # type
+        row[13],  # readable date
+    )
+    return key
+
+
 def add_sms(conn, root):
     log.debug("Rewriting into optimized XML...")
     cursor = conn.execute("SELECT COUNT() FROM smss")
@@ -70,7 +105,9 @@ def add_sms(conn, root):
     log.debug("Attempting to write new XML for SMS count: " + str(sms_count[0]))
     # Get the rows
     cursor = conn.execute("SELECT * FROM smss ORDER BY date_sent")
+    unique_sms = set()
     for row in cursor:
+        unique_sms.add(make_unique_message_key(row))
         # newfile.write("<sms protocol=\"%s\" body=\"%s\"/>\n" % (row[0], row[5]))
         sms_element = XML.SubElement(root, "sms")
         sms_element.set("protocol", row[0])
@@ -89,9 +126,18 @@ def add_sms(conn, root):
         sms_element.set("readable_date", row[13])
         sms_element.set("contact_name", row[14])
     conn.commit()
+    return unique_sms
 
 
-def add_mms(conn, root):
+def map_mms_type(mms_type):
+    # Sent and received types for MMS -> SMS
+    if mms_type == "151":
+        return "2"
+    elif mms_type == "137":
+        return "1"
+
+
+def add_mms(conn, root, unique_sms):
     log.debug("Rewriting into optimized XML...")
     cursor = conn.execute("SELECT COUNT() FROM mmss")
     mms_count = cursor.fetchone()
@@ -99,7 +145,10 @@ def add_mms(conn, root):
     log.debug("Attempting to write new XML for MMS count: " + str(mms_count[0]))
     # Get the rows
     cursorMMS = conn.execute("SELECT * FROM mmss ORDER BY date_sent")
-    for rowMMS in cursorMMS:
+    duplicates_skipped = 0
+    for row_num, rowMMS in enumerate(cursorMMS):
+        if not row_num % 250:
+            log.debug("Progress: {}/{}...".format(row_num, mms_count[0]))
         mms_element = XML.SubElement(root, "mms")
         # retrocompatibility
         mms_element.set("text_only", rowMMS[0])
@@ -235,8 +284,10 @@ def add_mms(conn, root):
             mms_element.set("privacy_mode", privacy_mode)
         # ----- write parts and addrs
         id_mms = rowMMS[55]
-        conn2 = sqlite3.connect('sms.db')
-        cursorParts = conn2.execute("SELECT * FROM parts WHERE fk_id_mms ="+str(id_mms))
+        conn2 = sqlite3.connect("sms.db")
+        cursorParts = conn2.execute(
+            "SELECT * FROM parts WHERE fk_id_mms =" + str(id_mms)
+        )
         parts_root = XML.SubElement(mms_element, "parts")
         for rowPart in cursorParts:
             part_element = XML.SubElement(parts_root, "part")
@@ -262,16 +313,32 @@ def add_mms(conn, root):
             else:
                 part_element.set("data", "null")
 
-        cursorAddrs = conn2.execute("SELECT * FROM addrs WHERE fk_id_mms ="+str(id_mms))
+        cursorAddrs = conn2.execute(
+            "SELECT * FROM addrs WHERE fk_id_mms =" + str(id_mms)
+        )
         addrs_root = XML.SubElement(mms_element, "addrs")
         for rowAddr in cursorAddrs:
             addr_element = XML.SubElement(addrs_root, "addr")
             addr_element.set("address", rowAddr[0])
             addr_element.set("type", rowAddr[1])
             addr_element.set("charset", rowAddr[2])
-        if 'conn2' in locals():
+            address_formatted = format_number(rowAddr[0])
+            unique_key = "{}-{}-{}".format(
+                address_formatted,  # address
+                map_mms_type(rowAddr[1]),  # type
+                rowMMS[51],  # readable_date
+            )
+            if unique_key in unique_sms:
+                log.debug("Found duplicate key {}.".format(unique_key))
+                duplicates_skipped += 1
+                root.remove(mms_element)
+                break
+
+        if "conn2" in locals():
             conn2.close()
+
     conn.commit()
+    return duplicates_skipped
 
 
 def insert_default(conn, sql, vals, child):
@@ -283,67 +350,86 @@ def insert_default(conn, sql, vals, child):
         # log.info("\tException: " + e.message)
         return False
     except sqlite3.OperationalError as e:
-        log.info("Skipping: Found OperationalError when processing child (%s): %s" % (child.tag, str(child)))
+        log.info(
+            "Skipping: Found OperationalError when processing child (%s): %s"
+            % (child.tag, str(child))
+        )
         log.info("\tException: " + e.message)
         return False
     return True
 
 
 def insert_sms(conn, child):
-    columns = ', '.join(child.attrib.keys())
-    placeholders = ', '.join('?' * len(child.attrib))
-    sql = 'INSERT INTO smss ({}) VALUES ({})'.format(columns, placeholders)
-    vals = child.attrib.values()
+    columns = list(child.attrib.keys())
+    vals = list(child.attrib.values())
+    if "sub_id" in columns:
+        sub_id_index = columns.index("sub_id")
+        vals.pop(sub_id_index)
+        columns.pop(sub_id_index)
+        columns = ", ".join(columns)
+    placeholders = ", ".join("?" * len(vals))
+    sql = "INSERT INTO smss ({}) VALUES ({})".format(columns, placeholders)
     return insert_default(conn, sql, vals, child)
 
 
-def mms_compatibility(child, columns):
+def mms_compatibility(attribs, columns):
     oppo_counter = columns.count("oppo")
-    columns = re.sub('(oppo_[a-z_]+,)', '', columns)
-    log.debug("columns %s" % columns)
-    placeholder_counter = (len(child.attrib)+1-oppo_counter)
-    placeholders = ', '.join('?' * placeholder_counter)
-    sql = 'INSERT INTO mmss ({}) VALUES ({})'.format(columns, placeholders)
+    columns = re.sub("(oppo_[a-z_]+,)", "", columns)
+    # log.debug("columns %s" % columns)
+    placeholder_counter = len(attribs) + 1 - oppo_counter
+    placeholders = ", ".join("?" * placeholder_counter)
+    sql = "INSERT INTO mmss ({}) VALUES ({})".format(columns, placeholders)
     return sql
 
+
 def insert_mms(conn, child):
-    columns = 'id ,'+', '.join(child.attrib.keys())
-    sql = mms_compatibility(child, columns)
-    #id_mms = conn.execute('SELECT IFNULL(MAX(id), 0) + 1 FROM mmss')
+    attribs = dict(child.attrib.items())
+    sequence_time = attribs.pop("sequence_time", None)
+    date = attribs.get("date")
+    if sequence_time and sequence_time != date:
+        log.debug("found sequence_time != date for child: " % child)
+    # TODO: should we handle _id?
+    _id = attribs.pop("_id", None)
+    star_status = attribs.pop("star_status", None)
+    if star_status and star_status != "null":
+        log.debug("found unhandled star_status value for child: " % child)
+    columns = "id ," + ", ".join(attribs.keys())
+    sql = mms_compatibility(attribs, columns)
+    # id_mms = conn.execute('SELECT IFNULL(MAX(id), 0) + 1 FROM mmss')
     global GLOB_ID_MMS
     id_mms = GLOB_ID_MMS
-    vals = child.attrib.values()
+    vals = list(attribs.values())
     vals.insert(0, id_mms)
     # ---------- PARTS AND ADDRS ---------------
     rst = insert_default(conn, sql, vals, child)
 
-    GLOB_ID_MMS = GLOB_ID_MMS+1
+    GLOB_ID_MMS = GLOB_ID_MMS + 1
     if rst:
-        child_parts = child.find('parts')
-        child_addrs = child.find('addrs')
+        child_parts = child.find("parts")
+        child_addrs = child.find("addrs")
         if child_parts is not None:
-            for child_part in child_parts.findall('part'):
+            for child_part in child_parts.findall("part"):
                 insert_part(conn, id_mms, child_part)
         if child_addrs is not None:
-            for child_addr in child_addrs.findall('addr'):
+            for child_addr in child_addrs.findall("addr"):
                 insert_addr(conn, id_mms, child_addr)
     return id_mms
 
 
 def insert_part(conn, id_mms, child_mms):
-    columns_part = 'fk_id_mms ,'+', '.join(child_mms.attrib.keys())
-    placeholders_part = ', '.join('?' * (len(child_mms.attrib)+1))
-    sql = 'INSERT INTO parts ({}) VALUES ({})'.format(columns_part, placeholders_part)
-    vals = child_mms.attrib.values()
+    columns_part = "fk_id_mms ," + ", ".join(child_mms.attrib.keys())
+    placeholders_part = ", ".join("?" * (len(child_mms.attrib) + 1))
+    sql = "INSERT INTO parts ({}) VALUES ({})".format(columns_part, placeholders_part)
+    vals = list(child_mms.attrib.values())
     vals.insert(0, id_mms)
     return insert_default(conn, sql, vals, child_mms)
 
 
 def insert_addr(conn, id_mms, child_mms):
-    columnsAddr = 'fk_id_mms ,'+', '.join(child_mms.attrib.keys())
-    placeholdersAddr = ', '.join('?' * (len(child_mms.attrib)+1))
-    sql = 'INSERT INTO addrs ({}) VALUES ({})'.format(columnsAddr, placeholdersAddr)
-    vals = child_mms.attrib.values()
+    columnsAddr = "fk_id_mms ," + ", ".join(child_mms.attrib.keys())
+    placeholdersAddr = ", ".join("?" * (len(child_mms.attrib) + 1))
+    sql = "INSERT INTO addrs ({}) VALUES ({})".format(columnsAddr, placeholdersAddr)
+    vals = list(child_mms.attrib.values())
     vals.insert(0, id_mms)
     return insert_default(conn, sql, vals, child_mms)
 
@@ -352,7 +438,7 @@ def load_into_db(conn, tree):
     root = tree.getroot()
     log.debug("Loading MMS data into DB...")
     num_skipped = 0
-    mms_list = []
+    total_records = 0
     for child in root:
         rst = False
         if child.tag == "mms":
@@ -361,36 +447,59 @@ def load_into_db(conn, tree):
             rst = insert_sms(conn, child)
         if not rst:
             num_skipped += 1
+        else:
+            total_records += 1
 
     root.clear()  # Clear this super huge tree. We don't need it anymore
     log.debug("Done duplicate check. Skipped duplicate entries: " + str(num_skipped))
     conn.commit()
-    return mms_list
+    return total_records
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='Combine XML files created with the program SMS Backup and restore.')
-    parser.add_argument('-i', '--input', metavar='infile', type=str, nargs='+',
-                        help='the input files to combine')
-    parser.add_argument('-o', '--output', metavar='outfile', type=str, nargs=1,
-                        help='the output file to write')
+    parser = argparse.ArgumentParser(
+        description="Combine XML files created with the program SMS Backup and restore."
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        metavar="infile",
+        type=str,
+        nargs="+",
+        help="the input files to combine",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        metavar="outfile",
+        type=str,
+        nargs=1,
+        help="the output file to write",
+    )
 
     args = parser.parse_args()
 
     input_path = set()
 
     for current_path in args.input:
-        temp_path = os.path.abspath(os.path.expandvars(os.path.expanduser(current_path)))
+        temp_path = os.path.abspath(
+            os.path.expandvars(os.path.expanduser(current_path))
+        )
 
         if os.path.isdir(temp_path):
-            unfiltered_list = [os.path.normpath(os.path.join(temp_path, x)) for x in os.listdir(temp_path)]
+            unfiltered_list = [
+                os.path.normpath(os.path.join(temp_path, x))
+                for x in os.listdir(temp_path)
+            ]
         else:
             unfiltered_list = glob.glob(temp_path)
 
         filtered_list = fnmatch.filter(unfiltered_list, "*.xml")
         input_path.update(filtered_list)
 
-    return input_path, os.path.abspath(os.path.expandvars(os.path.expanduser(args.output[0])))
+    return input_path, os.path.abspath(
+        os.path.expandvars(os.path.expanduser(args.output[0]))
+    )
 
 
 if __name__ == "__main__":

--- a/clean.py
+++ b/clean.py
@@ -68,6 +68,7 @@ def main(input_paths, output_path):
 
 def write_file(output_path, root):
     tree = XML.ElementTree(root)
+    XML.ElementTree.indent(tree)
     tree.write(output_path, xml_declaration=True, encoding="UTF-8")
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,111 @@
+[[package]]
+name = "lxml"
+version = "4.9.2"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
+
+[package.extras]
+cssselect = ["cssselect (>=0.7)"]
+html5 = ["html5lib"]
+htmlsoup = ["BeautifulSoup4"]
+source = ["Cython (>=0.29.7)"]
+
+[[package]]
+name = "phonenumbers"
+version = "8.13.7"
+description = "Python version of Google's common library for parsing, formatting, storing and validating international phone numbers."
+category = "main"
+optional = false
+python-versions = "*"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.11"
+content-hash = "d9408e33b5a033b9d9a49d4970b292c81130c82d5001d4feb95b5ddde45f8b2f"
+
+[metadata.files]
+lxml = [
+    {file = "lxml-4.9.2-cp27-cp27m-macosx_10_15_x86_64.whl", hash = "sha256:76cf573e5a365e790396a5cc2b909812633409306c6531a6877c59061e42c4f2"},
+    {file = "lxml-4.9.2-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b1f42b6921d0e81b1bcb5e395bc091a70f41c4d4e55ba99c6da2b31626c44892"},
+    {file = "lxml-4.9.2-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:9f102706d0ca011de571de32c3247c6476b55bb6bc65a20f682f000b07a4852a"},
+    {file = "lxml-4.9.2-cp27-cp27m-win32.whl", hash = "sha256:8d0b4612b66ff5d62d03bcaa043bb018f74dfea51184e53f067e6fdcba4bd8de"},
+    {file = "lxml-4.9.2-cp27-cp27m-win_amd64.whl", hash = "sha256:4c8f293f14abc8fd3e8e01c5bd86e6ed0b6ef71936ded5bf10fe7a5efefbaca3"},
+    {file = "lxml-4.9.2-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2899456259589aa38bfb018c364d6ae7b53c5c22d8e27d0ec7609c2a1ff78b50"},
+    {file = "lxml-4.9.2-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6749649eecd6a9871cae297bffa4ee76f90b4504a2a2ab528d9ebe912b101975"},
+    {file = "lxml-4.9.2-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:a08cff61517ee26cb56f1e949cca38caabe9ea9fbb4b1e10a805dc39844b7d5c"},
+    {file = "lxml-4.9.2-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:85cabf64adec449132e55616e7ca3e1000ab449d1d0f9d7f83146ed5bdcb6d8a"},
+    {file = "lxml-4.9.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:8340225bd5e7a701c0fa98284c849c9b9fc9238abf53a0ebd90900f25d39a4e4"},
+    {file = "lxml-4.9.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:1ab8f1f932e8f82355e75dda5413a57612c6ea448069d4fb2e217e9a4bed13d4"},
+    {file = "lxml-4.9.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:699a9af7dffaf67deeae27b2112aa06b41c370d5e7633e0ee0aea2e0b6c211f7"},
+    {file = "lxml-4.9.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b9cc34af337a97d470040f99ba4282f6e6bac88407d021688a5d585e44a23184"},
+    {file = "lxml-4.9.2-cp310-cp310-win32.whl", hash = "sha256:d02a5399126a53492415d4906ab0ad0375a5456cc05c3fc0fc4ca11771745cda"},
+    {file = "lxml-4.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:a38486985ca49cfa574a507e7a2215c0c780fd1778bb6290c21193b7211702ab"},
+    {file = "lxml-4.9.2-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:c83203addf554215463b59f6399835201999b5e48019dc17f182ed5ad87205c9"},
+    {file = "lxml-4.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:2a87fa548561d2f4643c99cd13131acb607ddabb70682dcf1dff5f71f781a4bf"},
+    {file = "lxml-4.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:d6b430a9938a5a5d85fc107d852262ddcd48602c120e3dbb02137c83d212b380"},
+    {file = "lxml-4.9.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:3efea981d956a6f7173b4659849f55081867cf897e719f57383698af6f618a92"},
+    {file = "lxml-4.9.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:df0623dcf9668ad0445e0558a21211d4e9a149ea8f5666917c8eeec515f0a6d1"},
+    {file = "lxml-4.9.2-cp311-cp311-win32.whl", hash = "sha256:da248f93f0418a9e9d94b0080d7ebc407a9a5e6d0b57bb30db9b5cc28de1ad33"},
+    {file = "lxml-4.9.2-cp311-cp311-win_amd64.whl", hash = "sha256:3818b8e2c4b5148567e1b09ce739006acfaa44ce3156f8cbbc11062994b8e8dd"},
+    {file = "lxml-4.9.2-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ca989b91cf3a3ba28930a9fc1e9aeafc2a395448641df1f387a2d394638943b0"},
+    {file = "lxml-4.9.2-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:822068f85e12a6e292803e112ab876bc03ed1f03dddb80154c395f891ca6b31e"},
+    {file = "lxml-4.9.2-cp35-cp35m-win32.whl", hash = "sha256:be7292c55101e22f2a3d4d8913944cbea71eea90792bf914add27454a13905df"},
+    {file = "lxml-4.9.2-cp35-cp35m-win_amd64.whl", hash = "sha256:998c7c41910666d2976928c38ea96a70d1aa43be6fe502f21a651e17483a43c5"},
+    {file = "lxml-4.9.2-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:b26a29f0b7fc6f0897f043ca366142d2b609dc60756ee6e4e90b5f762c6adc53"},
+    {file = "lxml-4.9.2-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:ab323679b8b3030000f2be63e22cdeea5b47ee0abd2d6a1dc0c8103ddaa56cd7"},
+    {file = "lxml-4.9.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:689bb688a1db722485e4610a503e3e9210dcc20c520b45ac8f7533c837be76fe"},
+    {file = "lxml-4.9.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:f49e52d174375a7def9915c9f06ec4e569d235ad428f70751765f48d5926678c"},
+    {file = "lxml-4.9.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:36c3c175d34652a35475a73762b545f4527aec044910a651d2bf50de9c3352b1"},
+    {file = "lxml-4.9.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a35f8b7fa99f90dd2f5dc5a9fa12332642f087a7641289ca6c40d6e1a2637d8e"},
+    {file = "lxml-4.9.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:58bfa3aa19ca4c0f28c5dde0ff56c520fbac6f0daf4fac66ed4c8d2fb7f22e74"},
+    {file = "lxml-4.9.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:bc718cd47b765e790eecb74d044cc8d37d58562f6c314ee9484df26276d36a38"},
+    {file = "lxml-4.9.2-cp36-cp36m-win32.whl", hash = "sha256:d5bf6545cd27aaa8a13033ce56354ed9e25ab0e4ac3b5392b763d8d04b08e0c5"},
+    {file = "lxml-4.9.2-cp36-cp36m-win_amd64.whl", hash = "sha256:3ab9fa9d6dc2a7f29d7affdf3edebf6ece6fb28a6d80b14c3b2fb9d39b9322c3"},
+    {file = "lxml-4.9.2-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:05ca3f6abf5cf78fe053da9b1166e062ade3fa5d4f92b4ed688127ea7d7b1d03"},
+    {file = "lxml-4.9.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:a5da296eb617d18e497bcf0a5c528f5d3b18dadb3619fbdadf4ed2356ef8d941"},
+    {file = "lxml-4.9.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:04876580c050a8c5341d706dd464ff04fd597095cc8c023252566a8826505726"},
+    {file = "lxml-4.9.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:c9ec3eaf616d67db0764b3bb983962b4f385a1f08304fd30c7283954e6a7869b"},
+    {file = "lxml-4.9.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2a29ba94d065945944016b6b74e538bdb1751a1db6ffb80c9d3c2e40d6fa9894"},
+    {file = "lxml-4.9.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a82d05da00a58b8e4c0008edbc8a4b6ec5a4bc1e2ee0fb6ed157cf634ed7fa45"},
+    {file = "lxml-4.9.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:223f4232855ade399bd409331e6ca70fb5578efef22cf4069a6090acc0f53c0e"},
+    {file = "lxml-4.9.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d17bc7c2ccf49c478c5bdd447594e82692c74222698cfc9b5daae7ae7e90743b"},
+    {file = "lxml-4.9.2-cp37-cp37m-win32.whl", hash = "sha256:b64d891da92e232c36976c80ed7ebb383e3f148489796d8d31a5b6a677825efe"},
+    {file = "lxml-4.9.2-cp37-cp37m-win_amd64.whl", hash = "sha256:a0a336d6d3e8b234a3aae3c674873d8f0e720b76bc1d9416866c41cd9500ffb9"},
+    {file = "lxml-4.9.2-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:da4dd7c9c50c059aba52b3524f84d7de956f7fef88f0bafcf4ad7dde94a064e8"},
+    {file = "lxml-4.9.2-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:821b7f59b99551c69c85a6039c65b75f5683bdc63270fec660f75da67469ca24"},
+    {file = "lxml-4.9.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:e5168986b90a8d1f2f9dc1b841467c74221bd752537b99761a93d2d981e04889"},
+    {file = "lxml-4.9.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:8e20cb5a47247e383cf4ff523205060991021233ebd6f924bca927fcf25cf86f"},
+    {file = "lxml-4.9.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:13598ecfbd2e86ea7ae45ec28a2a54fb87ee9b9fdb0f6d343297d8e548392c03"},
+    {file = "lxml-4.9.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:880bbbcbe2fca64e2f4d8e04db47bcdf504936fa2b33933efd945e1b429bea8c"},
+    {file = "lxml-4.9.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:7d2278d59425777cfcb19735018d897ca8303abe67cc735f9f97177ceff8027f"},
+    {file = "lxml-4.9.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5344a43228767f53a9df6e5b253f8cdca7dfc7b7aeae52551958192f56d98457"},
+    {file = "lxml-4.9.2-cp38-cp38-win32.whl", hash = "sha256:925073b2fe14ab9b87e73f9a5fde6ce6392da430f3004d8b72cc86f746f5163b"},
+    {file = "lxml-4.9.2-cp38-cp38-win_amd64.whl", hash = "sha256:9b22c5c66f67ae00c0199f6055705bc3eb3fcb08d03d2ec4059a2b1b25ed48d7"},
+    {file = "lxml-4.9.2-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:5f50a1c177e2fa3ee0667a5ab79fdc6b23086bc8b589d90b93b4bd17eb0e64d1"},
+    {file = "lxml-4.9.2-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:090c6543d3696cbe15b4ac6e175e576bcc3f1ccfbba970061b7300b0c15a2140"},
+    {file = "lxml-4.9.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:63da2ccc0857c311d764e7d3d90f429c252e83b52d1f8f1d1fe55be26827d1f4"},
+    {file = "lxml-4.9.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:5b4545b8a40478183ac06c073e81a5ce4cf01bf1734962577cf2bb569a5b3bbf"},
+    {file = "lxml-4.9.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2e430cd2824f05f2d4f687701144556646bae8f249fd60aa1e4c768ba7018947"},
+    {file = "lxml-4.9.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6804daeb7ef69e7b36f76caddb85cccd63d0c56dedb47555d2fc969e2af6a1a5"},
+    {file = "lxml-4.9.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a6e441a86553c310258aca15d1c05903aaf4965b23f3bc2d55f200804e005ee5"},
+    {file = "lxml-4.9.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ca34efc80a29351897e18888c71c6aca4a359247c87e0b1c7ada14f0ab0c0fb2"},
+    {file = "lxml-4.9.2-cp39-cp39-win32.whl", hash = "sha256:6b418afe5df18233fc6b6093deb82a32895b6bb0b1155c2cdb05203f583053f1"},
+    {file = "lxml-4.9.2-cp39-cp39-win_amd64.whl", hash = "sha256:f1496ea22ca2c830cbcbd473de8f114a320da308438ae65abad6bab7867fe38f"},
+    {file = "lxml-4.9.2-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:b264171e3143d842ded311b7dccd46ff9ef34247129ff5bf5066123c55c2431c"},
+    {file = "lxml-4.9.2-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:0dc313ef231edf866912e9d8f5a042ddab56c752619e92dfd3a2c277e6a7299a"},
+    {file = "lxml-4.9.2-pp38-pypy38_pp73-macosx_10_15_x86_64.whl", hash = "sha256:16efd54337136e8cd72fb9485c368d91d77a47ee2d42b057564aae201257d419"},
+    {file = "lxml-4.9.2-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:0f2b1e0d79180f344ff9f321327b005ca043a50ece8713de61d1cb383fb8ac05"},
+    {file = "lxml-4.9.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:7b770ed79542ed52c519119473898198761d78beb24b107acf3ad65deae61f1f"},
+    {file = "lxml-4.9.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:efa29c2fe6b4fdd32e8ef81c1528506895eca86e1d8c4657fda04c9b3786ddf9"},
+    {file = "lxml-4.9.2-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7e91ee82f4199af8c43d8158024cbdff3d931df350252288f0d4ce656df7f3b5"},
+    {file = "lxml-4.9.2-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:b23e19989c355ca854276178a0463951a653309fb8e57ce674497f2d9f208746"},
+    {file = "lxml-4.9.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:01d36c05f4afb8f7c20fd9ed5badca32a2029b93b1750f571ccc0b142531caf7"},
+    {file = "lxml-4.9.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7b515674acfdcadb0eb5d00d8a709868173acece5cb0be3dd165950cbfdf5409"},
+    {file = "lxml-4.9.2.tar.gz", hash = "sha256:2455cfaeb7ac70338b3257f41e21f0724f4b5b0c0e7702da67ee6c3640835b67"},
+]
+phonenumbers = [
+    {file = "phonenumbers-8.13.7-py2.py3-none-any.whl", hash = "sha256:d3e3555b38c89b121f5b2e917847003bdd07027569d758d5f40156c01aeac089"},
+    {file = "phonenumbers-8.13.7.tar.gz", hash = "sha256:253bb0e01250d21a11f2b42b3e6e161b7f6cb2ac440e2e2a95c1da71d221ee1a"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "AndroidSMSBackupRestoreCleaner"
+version = "0.1.0"
+description = ""
+authors = ["Paul Craciunoiu <paul@craciunoiu.net>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+phonenumbers = "^8.13.7"
+lxml = "^4.9.2"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
- Enhance duplicate detection between SMS and MMS
- Format phone numbers for duplicate detection
- Upgrade to python 3 (tested in 3.11)
- Add more debug/log output to help with progress

Functionality tested on a database of almost 1GB, with 100K+ messages (about 50/50 SMS/MMS).

TODOs for future:
- Update CREATE TABLE instead, like here: https://github.com/hameerabbasi/AndroidSMSBackupRestoreCleaner/issues/2
- Add text.xml file with duplicates